### PR TITLE
added module version workflo

### DIFF
--- a/.github/workflows/moduleVersion.yml
+++ b/.github/workflows/moduleVersion.yml
@@ -72,8 +72,8 @@ jobs:
       - name: commit changes
         run: |
           git branch
-          git config --global user.name 'Matthew Bratschun'
-          git config --global user.email 'mbratschun@microsoft.com'
+          git config --global user.name 'Automated GitHub Action'
+          git config --global user.email 'no-reply@github.com'
 
           git add -A
           git commit -am "incremented changed module versions: $(git log -1 --pretty=%B)"

--- a/.github/workflows/moduleVersion.yml
+++ b/.github/workflows/moduleVersion.yml
@@ -38,7 +38,13 @@ jobs:
           $moduleChangedFileList = $files | where-object { $_ -match '\.psm1$'}
 
           ForEach ($moduleChangedFile in $moduleChangedFileList) {
-              $moduleManifestPath = Get-Item -Path ($moduleChangedFile -replace '\.psm1$','.psd1')
+
+              try {
+                $moduleManifestPath = Get-Item -Path ($moduleChangedFile -replace '\.psm1$','.psd1') -ErrorAction Stop
+              }
+              catch {
+                Write-Error "Error locating .psd1 file for module '$moduleChangedFile'. This file should reside in the same directory as the psm1."
+              }
               
               $moduleManifest = Get-Item $moduleManifestPath
               $content = Get-Content $moduleManifest

--- a/.github/workflows/moduleVersion.yml
+++ b/.github/workflows/moduleVersion.yml
@@ -1,0 +1,80 @@
+# This workflow increments the build version of changed PS modules files in the associated PR
+
+name: Increment Module Versions
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    branches: [ "main" ]
+
+
+
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - id: files
+        uses: jitterbit/get-changed-files@v1
+        continue-on-error: true
+        with:
+          format: json
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          # Automatically increment the 'build' version numbers on a PS module file
+          
+          $files = '${{ steps.files.outputs.modified }}' | ConvertFrom-Json
+          
+          $moduleVersionRegex = [regex]"(?:ModuleVersion\s?=\s?')([\d\.]*)'" 
+
+          $moduleChangedFileList = $files | where-object { $_ -match '\.psm1$'}
+
+          ForEach ($moduleChangedFile in $moduleChangedFileList) {
+              $moduleManifestPath = Get-Item -Path ($moduleChangedFile -replace '\.psm1$','.psd1')
+              
+              $moduleManifest = Get-Item $moduleManifestPath
+              $content = Get-Content $moduleManifest
+
+              If ($moduleVersionMatches = $moduleVersionRegex.matches($content)) {
+                  If ($moduleVersionMatches.count -eq 1) {
+                      $moduleVersionLine = $moduleVersionMatches[0].Groups[0].Value
+                      $currentModuleVersion = $moduleVersionMatches[0].Groups[1].Value
+
+                      If ($version = $currentModuleVersion -as [version]) {
+                          $major = $version.Major
+                          $minor = $version.Minor
+                          $build = $version.Build + 1 # add 1 to current version build number
+
+                          $newVersion = [version]::new($major,$minor,$build)
+                      }
+                      Else {
+                          Write-Error "Version string '$currentModuleVersion' cannot be converted to type [Version]. File: '$moduleManifest'"
+                      }
+
+                      $newVersionLine = $moduleVersionLine -replace $currentModuleVersion,$newVersion
+
+                      $moduleManifest | Set-Content -Value ($content -replace $moduleVersionLine,$newVersionLine)
+                  }
+                  Else {
+                      Write-Error "More than one matches for regex '$moduleVersionRegex' found in file '$moduleManifest'"
+                  }
+              }
+          }
+        shell: pwsh
+      - name: commit changes
+        run: |
+          git branch
+          git config --global user.name 'Matthew Bratschun'
+          git config --global user.email 'mbratschun@microsoft.com'
+
+          git add -A
+          git commit -am "incremented changed module versions: $(git log -1 --pretty=%B)"
+          git push


### PR DESCRIPTION
## Overview/Summary

Adds a GitHub workflow definition which automatically increments PowerShell module version build number for modules where the PSM1 file was modified in the associated pull request. Module version changes are committed to the PR source branch in a new commit after the action completes successfully. 

## This PR fixes/adds/changes/removes

1. .github/workflows/moduleVersion.yml

### Breaking Changes

## Testing Evidence

![image](https://user-images.githubusercontent.com/25390936/179317478-f5c9bc18-f4a2-40ea-8148-731f8e8ee30d.png)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
