### PR TITLE
Excluded CloudPosture, KubernetesService, ContainerRegistry from Defender for Cloud Pricing Evauation

### DIFF
--- a/src/GUARDRAIL 11 LOGGING AND MONITORING/Audit/Check-LoggingAndMonitoring.psm1
+++ b/src/GUARDRAIL 11 LOGGING AND MONITORING/Audit/Check-LoggingAndMonitoring.psm1
@@ -298,7 +298,7 @@ https://docs.microsoft.com/en-us/azure/automation/how-to/region-mappings
             $Comments= $msgTable.noSecurityContactInfo -f $sub.Name
             $MitigationCommands += $msgTable.setSecurityContact -f $sub.Name
         }
-        if ((Get-AzSecurityPricing | Select-Object PricingTier | Where-Object {$_.PricingTier -eq 'Free'}).Count -gt 0)
+        if ((Get-AzSecurityPricing | Where-Object {$_.PricingTier -eq 'Free' -and $_.Name -ne "CloudPosture"}).Count -gt 0)
         {
             $IsCompliant=$false
             $Comments += $msgTable.notAllDfCStandard -f $sub.Name

--- a/src/GUARDRAIL 11 LOGGING AND MONITORING/Audit/Check-LoggingAndMonitoring.psm1
+++ b/src/GUARDRAIL 11 LOGGING AND MONITORING/Audit/Check-LoggingAndMonitoring.psm1
@@ -298,7 +298,11 @@ https://docs.microsoft.com/en-us/azure/automation/how-to/region-mappings
             $Comments= $msgTable.noSecurityContactInfo -f $sub.Name
             $MitigationCommands += $msgTable.setSecurityContact -f $sub.Name
         }
-        if ((Get-AzSecurityPricing | Where-Object {$_.PricingTier -eq 'Free' -and $_.Name -ne "CloudPosture"}).Count -gt 0)
+        
+        # We need to exlude 
+        # - CloudPosture since this plan is always shows as Free
+        # - KubernetesService and ContainerRegistry because two plans are deprecated in favor of the Container plan.
+        if ((Get-AzSecurityPricing | Where-Object {$_.PricingTier -eq 'Free' -and $_.Name -ne "CloudPosture" -and $_.Name -ne "KubernetesService" -and $_.Name -ne "ContainerRegistry"}).Count -gt 0)
         {
             $IsCompliant=$false
             $Comments += $msgTable.notAllDfCStandard -f $sub.Name


### PR DESCRIPTION
## Overview/Summary

This PR will fix the evaluation of Guardrail 11 (ITSG AC2(12)). 

## This PR fixes/adds/changes/removes

1. It exclude CloudPosture plan since this plan is Free and can't be changed for now.
2. It exclude KubernetesService and ContainerRegistry since those 2 plans are now deprecated in favor of Container Plan

### Breaking Changes

N/A

## Testing Evidence

![image](https://user-images.githubusercontent.com/114452616/193065557-3af7479b-341b-4d57-a591-e3248b6b9345.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
