### PR TITLE
GR 8: Handle Empty VNET List

### DIFF
--- a/src/GUARDRAIL 8 NETWORK SEGMENTATION AND SEPARATION/Audit/Check-SubnetComplianceStatus.psd1
+++ b/src/GUARDRAIL 8 NETWORK SEGMENTATION AND SEPARATION/Audit/Check-SubnetComplianceStatus.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\Check-SubnetComplianceStatus.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.2'
+ModuleVersion = '1.1.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

When all VNETs are excluded from evaluation by tag, corrected module output to pass the same 'no subnets found' output. Simplified the tag check logics for VNETs. 

#299 (ignore branch name!)

## Testing Evidence

Deployed both with all VNETs excluded and only some excluded and did not receive errors 

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
