### PR TITLE
Add Cloud Usage Profiles to Config and Workbook

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,6 +70,7 @@ All named resources will have the first 6 characters of the tenant Id appended t
 |lighthousePrincipalId|If using Lighthouse cross-tenant delegated access to Guardrails data, specify the object ID (GUID) of the Azure AD principal (group or user) to be delegated access to your Guardrails resource group|
 |lighthouseTargetManagementGroupID|If using Lighthouse cross-tenant delegated access to Guardrails data, specify the name of the Management Group under which all subscriptions will grant Defender for Cloud access to the managing tenant|
 |securityRetentionDays | Defines the minimum number retention days for the Security Log Analytics workspace provided. 730 days by default. Can be changed to accommodate other scenarios.|
+|cloudUsageProfiles| Specifies the Cloud Usage Profiles as a comma-separated string. Example: "1,2,3" Default value is: "default" |
 
 Save the file and exit VSCode [Ctrl+S] & [Ctrl+Q] .
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,7 +70,7 @@ All named resources will have the first 6 characters of the tenant Id appended t
 |lighthousePrincipalId|If using Lighthouse cross-tenant delegated access to Guardrails data, specify the object ID (GUID) of the Azure AD principal (group or user) to be delegated access to your Guardrails resource group|
 |lighthouseTargetManagementGroupID|If using Lighthouse cross-tenant delegated access to Guardrails data, specify the name of the Management Group under which all subscriptions will grant Defender for Cloud access to the managing tenant|
 |securityRetentionDays | Defines the minimum number retention days for the Security Log Analytics workspace provided. 730 days by default. Can be changed to accommodate other scenarios.|
-|cloudUsageProfiles| Specifies the Cloud Usage Profiles as a comma-separated string. Example: "1,2,3" Default value is: "default" |
+|cloudUsageProfiles| Specifies the [Cloud Usage Profiles](https://github.com/canada-ca/cloud-guardrails/blob/master/EN/00_Applicable-Scope.md) as a comma-separated string. Example: "1,2,3" Default value is: "default" |
 
 Save the file and exit VSCode [Ctrl+S] & [Ctrl+Q] .
 

--- a/setup/IaC/guardrails.bicep
+++ b/setup/IaC/guardrails.bicep
@@ -30,6 +30,7 @@ param updateCoreResources bool = false
 param updatePSModules bool = false
 param updateWorkbook bool = false
 param securityRetentionDays string 
+param cloudUsageProfiles string = 'default'
 @secure()
 param breakglassAccount1 string = ''
 @secure()
@@ -75,6 +76,7 @@ module aa 'modules/automationaccount.bicep' = if (newDeployment || updatePSModul
     updatePSModules: updatePSModules
     updateCoreResources: updateCoreResources
     securityRetentionDays: securityRetentionDays
+    cloudUsageProfiles: cloudUsageProfiles
   }
 }
 module KV 'modules/keyvault.bicep' = if (newDeployment && deployKV) {

--- a/setup/IaC/modules/automationaccount.bicep
+++ b/setup/IaC/modules/automationaccount.bicep
@@ -22,6 +22,7 @@ param TenantDomainUPN string
 param updatePSModules bool = false
 param updateCoreResources bool = false
 param securityRetentionDays string
+param cloudUsageProfiles string = 'default'
 
 resource guardrailsAC 'Microsoft.Automation/automationAccounts@2021-06-22' = if (newDeployment || updatePSModules || updateCoreResources) {
   name: automationAccountName
@@ -429,6 +430,13 @@ resource module14 'modules' = if (newDeployment || updatePSModules) {
     'properties': {
       'isEncrypted': true
       'value': '"${securityRetentionDays}"'
+  }
+  }
+  resource variable21 'variables' = if (newDeployment || updateCoreResources) {
+    name: 'cloudUsageProfiles'
+    'properties': {
+      'isEncrypted': true
+      'value': '"${cloudUsageProfiles}"'
   }
   }
 }

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -800,6 +800,7 @@
         "version": "KqlItem/1.0",
         "query": "let dt = GR_VersionInfo_CL | summarize max(ReportTime_s);\nGR_VersionInfo_CL\n| where ReportTime_s == toscalar (dt)\n|project [\"Deployed Version\"]= DeployedVersion_s, [\"Version Available\"]=AvailableVersion_s, [\"Update Required\"]=iff(UpdateNeeded_b==true,\"Yes\",\"No\"),[\"Check date\"]=toscalar (dt)",
         "size": 4,
+        "title": "Guardrails Version Information",
         "timeContext": {
           "durationMs": 86400000
         },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -819,6 +819,7 @@
         "version": "KqlItem/1.0",
         "query": "let dt = GR_TenantInfo_CL | summarize max(ReportTime_s);\r\nGR_TenantInfo_CL\r\n| where ReportTime_s == toscalar (dt)\r\n| project [\"Cloud Usage Profiles\"] = iff(cloudUsageProfiles_s == 'default',toscalar(\"No Cloud Profile Data Found\"),cloudUsageProfiles_s),[\"Report Time\"]=toscalar (dt)",
         "size": 0,
+        "title": "Cloud Usage Profile Configuration",
         "timeContext": {
           "durationMs": 86400000
         },

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -818,7 +818,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let dt = GR_TenantInfo_CL | summarize max(ReportTime_s);\r\nGR_TenantInfo_CL\r\n| where ReportTime_s == toscalar (dt)\r\n| project [\"Cloud Usage Profiles\"] = iff(cloudUsageProfiles_s == 'default',toscalar(\"No Cloud Profile Data Found\"),cloudUsageProfiles_s),[\"Report Time\"]=toscalar (dt)",
+        "query": "let dt = GR_TenantInfo_CL | summarize max(ReportTime_s);\r\nGR_TenantInfo_CL\r\n| where ReportTime_s == toscalar (dt)\r\n| project [\"Cloud Usage Profiles\"] = iff(cloudUsageProfiles_s == 'default',toscalar(\"Cloud Usage Profile not specified or 'default'\"),cloudUsageProfiles_s),[\"Report Time\"]=toscalar (dt)",
         "size": 0,
         "title": "Cloud Usage Profile Configuration",
         "timeContext": {

--- a/setup/IaC/modules/gr.workbook
+++ b/setup/IaC/modules/gr.workbook
@@ -812,6 +812,26 @@
         "value": "information"
       },
       "name": "information"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let dt = GR_TenantInfo_CL | summarize max(ReportTime_s);\r\nGR_TenantInfo_CL\r\n| where ReportTime_s == toscalar (dt)\r\n| project [\"Cloud Usage Profiles\"] = iff(cloudUsageProfiles_s == 'default',toscalar(\"No Cloud Profile Data Found\"),cloudUsageProfiles_s),[\"Report Time\"]=toscalar (dt)",
+        "size": 0,
+        "timeContext": {
+          "durationMs": 86400000
+        },
+        "queryType": 0,
+        "resourceType": "microsoft.operationalinsights/workspaces",
+        "visualization": "card"
+      },
+      "conditionalVisibility": {
+        "parameterName": "selectedTab",
+        "comparison": "isEqualTo",
+        "value": "information"
+      },
+      "name": "query - 20"
     }
   ],
   "fallbackResourceIds": [

--- a/setup/backend.ps1
+++ b/setup/backend.ps1
@@ -35,6 +35,7 @@ $Locale=Get-GSAAutomationVariable -Name "GuardRailsLocale"
 $lighthouseTargetManagementGroupID = Get-GSAAutomationVariable -Name lighthouseTargetManagementGroupID -ErrorAction SilentlyContinue
 $DepartmentName = Get-GSAAutomationVariable -Name "DepartmentName" 
 $DepartmentNumber = Get-GSAAutomationVariable -Name "DepartmentNumber" 
+$cloudUsageProfiles = Get-GSAAutomationVariable -Name "cloudUsageProfiles"
 
 # Connects to Azure using the Automation Account's managed identity
 try {
@@ -61,7 +62,9 @@ get-itsgdata -URL $itsgURL -WorkSpaceID $WorkSpaceID -workspaceKey $WorkspaceKey
 Check-UpdateAvailable -WorkSpaceID  $WorkSpaceID -WorkspaceKey $WorkspaceKey -ReportTime $ReportTime
 
 # Updates Tenant info.
-Add-TenantInfo -WorkSpaceID  $WorkSpaceID -WorkspaceKey $WorkspaceKey -ReportTime $ReportTime -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber
+Add-TenantInfo -WorkSpaceID  $WorkSpaceID -WorkspaceKey $WorkspaceKey -ReportTime $ReportTime -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber -CloudUsageProfiles $cloudUsageProfiles
+
+# Update cloudUsageProfiles
 
 # Ensure the 'Microsoft.ManagedServices' resource provider is registered under each subscription at the delegated management group
 If ($lighthouseTargetManagementGroupID) {

--- a/setup/config.json
+++ b/setup/config.json
@@ -19,5 +19,6 @@
   "lighthousePrincipalDisplayName": "",
   "lighthousePrincipalId": "",
   "lighthouseTargetManagementGroupID": "",
-  "securityRetentionDays": "730"
+  "securityRetentionDays": "730",
+  "cloudUsageProfiles": "default"
 }

--- a/src/Guardrails-Common/GR-Common.psd1
+++ b/src/Guardrails-Common/GR-Common.psd1
@@ -12,7 +12,7 @@
 RootModule = 'GR-Common'
 
 # Version number of this module.
-ModuleVersion = '1.1.10'
+ModuleVersion = '1.1.11'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Guardrails-Common/GR-Common.psm1
+++ b/src/Guardrails-Common/GR-Common.psm1
@@ -239,7 +239,10 @@ Function Add-TenantInfo {
         $DepartmentName,
         [Parameter(Mandatory = $true)]
         [string]
-        $DepartmentNumber
+        $DepartmentNumber,
+        [Parameter(Mandatory = $true)]
+        [string]
+        $cloudUsageProfiles
     )
     $tenantInfo = Get-GSAAutomationVariable("tenantDomainUPN")
     $object = [PSCustomObject]@{ 
@@ -248,6 +251,7 @@ Function Add-TenantInfo {
         ReportTime         = $ReportTime
         DepartmentName     = $DepartmentName
         DepartmentNumber   = $DepartmentNumber
+        cloudUsageProfiles = $cloudUsageProfiles
     }
     if ($debug) { Write-Output $tenantInfo }
     $JSON = ConvertTo-Json -inputObject $object


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

#328 

## This PR fixes/adds/changes/removes

1. Addcs 'cloudUsageProfiles' to config
2. Updates AA deployment to copy value from config to variable
3. Updates Backend runbook to copy variable to log analytics
4. Updates workbook to display value

## Testing Evidence

No data/default description changed from below to `Cloud Usage Profile not specified or 'default'`
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/25390936/e9c47b74-ceb1-45ae-96df-4862a031d9b2)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
