### PR TITLE
add missing -cloudUsageProfiles param to Add-TenantInfo

### DIFF
--- a/ado-signing-pipeline-development.yml
+++ b/ado-signing-pipeline-development.yml
@@ -378,6 +378,13 @@ steps:
         Write-Output "'main' runbook completed successfully, checking for errors in output. "
       }
 
+      If ($jobBackend.Status -eq 'Failed') {
+        throw "backend runbook failed to execute"
+      }
+      If ($jobBackend.Status -eq 'Completed') {
+        Write-Output "'backend' runbook completed successfully, checking for errors in output. "
+      }
+
       $jobMainOutput = Get-AzAutomationJobOutput -Id $jobMain.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
       $jobBackendOutput = Get-AzAutomationJobOutput -Id $jobBackend.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
 

--- a/ado-signing-pipeline-development.yml
+++ b/ado-signing-pipeline-development.yml
@@ -355,33 +355,44 @@ steps:
       $c = Get-GSAExportedConfig -KeyVaultName gsapipe-$(uniqueNameSuffix) -y
       $config = $c.configString | ConvertFrom-Json
       
-      Write-Output "Waiting for 'main' runbook job to complete (up to 5 mins)"
+      Write-Output "Waiting for 'main' and 'backend' runbook jobs to complete (up to 5 mins)"
       $timeout = New-TimeSpan -Minutes 5
       $timer = [System.Diagnostics.Stopwatch]::StartNew()
       do {
-        $job = Get-AzAutomationJob -RunbookName 'main' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
+        $jobMain = Get-AzAutomationJob -RunbookName 'main' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
+          Sort-Object StartTIme -Descending |
+          Select-Object -First 1
+        
+        $jobBackend = Get-AzAutomationJob -RunbookName 'backend' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
           Sort-Object StartTIme -Descending |
           Select-Object -First 1
         
         Start-Sleep 1
       }
-      until (($job.Status -in 'Completed','Failed') -or ($timer.Elapsed -ge $timeout))
+      until (($jobMain.Status -in 'Completed','Failed' -and $jobBackend -in 'Completed','Failed') -or ($timer.Elapsed -ge $timeout))
 
-      If ($job.Status -eq 'Failed') {
+      If ($jobMain.Status -eq 'Failed') {
         throw "main runbook failed to execute"
       }
-      If ($job.Status -eq 'Completed') {
+      If ($jobMain.Status -eq 'Completed') {
         Write-Output "'main' runbook completed successfully, checking for errors in output. "
       }
 
-      $jobOutput = Get-AzAutomationJobOutput -Id $job.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
+      $jobMainOutput = Get-AzAutomationJobOutput -Id $jobMain.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
+      $jobBackendOutput = Get-AzAutomationJobOutput -Id $jobBackend.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
 
       $errorsFound = $false
-      ForEach ($outputRecord in $jobOutput) {
+      ForEach ($outputRecord in $jobMainOutput) {
         If ($outputRecord.Summary -like 'Failed invoke the module execution script for module*') {
-          throw 'Errors found in Azure Automation jobs'
+          throw 'Errors found in "main" runbook Azure Automation jobs'
         }
       }
+      ForEach ($outputRecord in $jobBackendOutput) {
+        If ($outputRecord.Summary -like 'Failed invoke the module execution script for module*') {
+          throw 'Errors found in "backend" runbook Azure Automation jobs'
+        }
+      }
+
       If (!$errorsFound) {
         #Write-Output ("##vso[task.setvariable variable=skipCleanup;isOutput=true]$($false)")
       }

--- a/ado-signing-pipeline-release.yml
+++ b/ado-signing-pipeline-release.yml
@@ -385,6 +385,13 @@ steps:
         Write-Output "'main' runbook completed successfully, checking for errors in output. "
       }
 
+      If ($jobBackend.Status -eq 'Failed') {
+        throw "backend runbook failed to execute"
+      }
+      If ($jobBackend.Status -eq 'Completed') {
+        Write-Output "'backend' runbook completed successfully, checking for errors in output. "
+      }
+
       $jobMainOutput = Get-AzAutomationJobOutput -Id $jobMain.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
       $jobBackendOutput = Get-AzAutomationJobOutput -Id $jobBackend.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
 

--- a/ado-signing-pipeline-release.yml
+++ b/ado-signing-pipeline-release.yml
@@ -362,33 +362,44 @@ steps:
       $c = Get-GSAExportedConfig -KeyVaultName gsapipe-$(uniqueNameSuffix) -y
       $config = $c.configString | ConvertFrom-Json
       
-      Write-Output "Waiting for 'main' runbook job to complete (up to 5 mins)"
+      Write-Output "Waiting for 'main' and 'backend' runbook jobs to complete (up to 5 mins)"
       $timeout = New-TimeSpan -Minutes 5
       $timer = [System.Diagnostics.Stopwatch]::StartNew()
       do {
-        $job = Get-AzAutomationJob -RunbookName 'main' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
+        $jobMain = Get-AzAutomationJob -RunbookName 'main' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
+          Sort-Object StartTIme -Descending |
+          Select-Object -First 1
+        
+        $jobBackend = Get-AzAutomationJob -RunbookName 'backend' -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName | 
           Sort-Object StartTIme -Descending |
           Select-Object -First 1
         
         Start-Sleep 1
       }
-      until (($job.Status -in 'Completed','Failed') -or ($timer.Elapsed -ge $timeout))
+      until (($jobMain.Status -in 'Completed','Failed' -and $jobBackend -in 'Completed','Failed') -or ($timer.Elapsed -ge $timeout))
 
-      If ($job.Status -eq 'Failed') {
+      If ($jobMain.Status -eq 'Failed') {
         throw "main runbook failed to execute"
       }
-      If ($job.Status -eq 'Completed') {
+      If ($jobMain.Status -eq 'Completed') {
         Write-Output "'main' runbook completed successfully, checking for errors in output. "
       }
 
-      $jobOutput = Get-AzAutomationJobOutput -Id $job.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
+      $jobMainOutput = Get-AzAutomationJobOutput -Id $jobMain.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
+      $jobBackendOutput = Get-AzAutomationJobOutput -Id $jobBackend.JobId -ResourceGroupName $config.runtime.resourceGroup -AutomationAccountName $config.runtime.automationAccountName -Stream 'Error'
 
       $errorsFound = $false
-      ForEach ($outputRecord in $jobOutput) {
+      ForEach ($outputRecord in $jobMainOutput) {
         If ($outputRecord.Summary -like 'Failed invoke the module execution script for module*') {
-          throw 'Errors found in Azure Automation jobs'
+          throw 'Errors found in "main" runbook Azure Automation jobs'
         }
       }
+      ForEach ($outputRecord in $jobBackendOutput) {
+        If ($outputRecord.Summary -like 'Failed invoke the module execution script for module*') {
+          throw 'Errors found in "backend" runbook Azure Automation jobs'
+        }
+      }
+
       If (!$errorsFound) {
         #Write-Output ("##vso[task.setvariable variable=skipCleanup;isOutput=true]$($false)")
       }

--- a/setup/backend.ps1
+++ b/setup/backend.ps1
@@ -66,7 +66,7 @@ $response = Invoke-AzRestMethod -Method get -uri 'https://graph.microsoft.com/v1
 $tenantName = $response.value.displayName
 
 Add-TenantInfo -WorkSpaceID  $WorkSpaceID -WorkspaceKey $WorkspaceKey -ReportTime $ReportTime `
-               -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber -tenantName $tenantName
+               -TenantId $tenantID -DepartmentName $DepartmentName -DepartmentNumber $DepartmentNumber -tenantName $tenantName -cloudUsageProfiles $cloudUsageProfiles
 
 # Ensure the 'Microsoft.ManagedServices' resource provider is registered under each subscription at the delegated management group
 If ($lighthouseTargetManagementGroupID) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

In Backend runbook, call to Add-TenantInfo was missing the -CloudUsageProfiles parameter

## This PR fixes/adds/changes/removes

1. Add param and value to call
2. Adds 'backend' runbook check to testing pipeline (previously, only checked 'main')

## Testing Evidence

![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/25390936/9b58f0f2-cfc3-4c02-b59c-50fec3630a6f)
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/25390936/a21dea3d-e28b-4747-93f9-36b9965a981e)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
