### PR TITLE
Fetch runtime config from keyvault to set AZ context to correct subscription

### DIFF
--- a/setup/main.ps1
+++ b/setup/main.ps1
@@ -92,6 +92,13 @@ If ($Locale -eq $null) {
     $Locale = "en-CA"
 }
 
+try {
+    $RuntimeConfig = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'gsaConfigExportLatest' -AsPlainText -ErrorAction Stop | ConvertFrom-Json | Select-Object -Expand runtime
+    Set-AzContext -SubscriptionId $RuntimeConfig.subscriptionId
+}
+catch {
+    throw "Failed to retrieve config json with secret name gsaConfigExportLatest from KeyVault '$KeyVaultName'. Error message: $_"
+}
 
 $SubID = (Get-AzContext).Subscription.Id
 $tenantID = (Get-AzContext).Tenant.Id


### PR DESCRIPTION
## Overview/Summary
This PR fixes #451 
If a client has multiple subscriptions, runbook context gets set to default subscription.
So if Azure CAC solution is installed on subscription other than the default subscription, it ends up trying to search resources in default subscription and fails.
This explains why the issue occurs for some clients while works for others.
Similar issue has been recorded in this issue. https://github.com/Azure/azure-powershell/issues/11377



## This PR fixes

1. Finds the subscription id of Azure CAC solution programmatically using runtime config stored in key vault and ensure runbooks AZ Context is set to that.

### Breaking Changes
N/A

## Testing Evidence
![MicrosoftTeams-image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/146129702/ba720be1-0277-4dc4-bf9f-754f6806a44c)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
