### PR TITLE
Update main.ps1

### DIFF
--- a/setup/main.ps1
+++ b/setup/main.ps1
@@ -10,7 +10,7 @@ function Get-GSAAutomationVariable {
 
     Write-Debug "Getting automation variable '$name'"
     # when running in an Azure Automation Account
-    If ($ENV:AZUREPS_HOST_ENVIRONMENT -eq 'AzureAutomation/') {
+    If ($ENV:AZUREPS_HOST_ENVIRONMENT -eq 'AzureAutomation/' -or $PSPrivateMetadata.JobId) {
         $value = Get-AutomationVariable -Name $name
         return $value
     }


### PR DESCRIPTION
Fix automation account detection

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The code was erroring when running inside the automation account. It was failing to detect that it was inside the automation account and was trying to lookup the key vault instead.


> Get-AzKeyVaultSecret : Cannot validate argument on parameter 'VaultName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again. At line:25 char:60 + ... cretValue = Get-AzKeyVaultSecret -VaultName $ENV:KeyvaultName -Name $ ... + ~~~~~~~~~~~~~~~~~ + CategoryInfo : InvalidData: (:) [Get-AzKeyVaultSecret], ParameterBindingValidationException + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.Azure.Commands.KeyVault.GetAzureKeyVaultSecret

We should not be getting to line 25 in an automation account.


Fix reference: https://stackoverflow.com/questions/37224874/what-is-the-correct-way-to-detect-whether-a-script-is-running-in-azure-automatio/71342637#71342637

## This PR fixes/adds/changes/removes

1. fix if statement

### Breaking Changes

n/a

## Testing Evidence

It stops crashing after the fix.

![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/9356891/0550ce08-8944-4964-a409-e79a0daa89c0)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
