### PR TITLE
update backend.ps1 to detect when runbook running in automation account

### DIFF
--- a/setup/backend.ps1
+++ b/setup/backend.ps1
@@ -5,7 +5,7 @@ function Get-GSAAutomationVariable {
 
     Write-Verbose "Getting automation variable '$name'"
     # when running in an Azure Automation Account
-    If ($ENV:AZUREPS_HOST_ENVIRONMENT -eq 'AzureAutomation/') {
+    If ($ENV:AZUREPS_HOST_ENVIRONMENT -eq 'AzureAutomation/' -or $PSPrivateMetadata.JobId) {
         $value = Get-AutomationVariable -Name $name
         return $value
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
fixes #455 
Code was failing to detect that it was inside the automation account and was trying to lookup the key vault instead.
Similar to fix in #454 

## This PR fixes/adds/changes/removes

1.  Changes the way we detect if runbook is running in automation account than just relying on environment variable AZUREPS_HOST_ENVIRONMENT

### Breaking Changes
N/A
## Testing Evidence
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/146129702/7856baac-0d17-4709-ad29-938fef330e74)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
