### PR TITLE
update backend.ps1 to detect right subscription to change context

### DIFF
--- a/setup/backend.ps1
+++ b/setup/backend.ps1
@@ -44,8 +44,17 @@ try {
 catch {
     throw "Critical: Failed to connect to Azure with the 'Connect-AzAccount' command and '-identity' (MSI) parameter; verify that Azure Automation identity is configured. Error message: $_"
 }
+
+try {
+    $RuntimeConfig = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name 'gsaConfigExportLatest' -AsPlainText -ErrorAction Stop | ConvertFrom-Json | Select-Object -Expand runtime
+    Set-AzContext -SubscriptionId $RuntimeConfig.subscriptionId
+}
+catch {
+    throw "Failed to retrieve config json with secret name gsaConfigExportLatest from KeyVault '$KeyVaultName'. Error message: $_"
+}
 $SubID = (Get-AzContext).Subscription.Id
 $tenantID = (Get-AzContext).Tenant.Id
+
 try {
     [String] $WorkspaceKey = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $GuardrailWorkspaceIDKeyName -AsPlainText -ErrorAction Stop
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
fixes #458 
This is a similar issue as #451 
https://github.com/Azure/GuardrailsSolutionAccelerator/blob/cbabaf82f906ad944048225899c61cb0eccff137/src/Guardrails-Common/GR-Common.psm1#L402
Above tries to get automation variable "ResourceGroupName" but is not able to find it as the current context of subscription is set to not the same subscription where runbook is being run of.
This issue occurs for clients with multiple subscriptions in the same tenant. 

## This PR fixes/adds/changes/removes

1. To resolve this, we query keyVault to find the right subscription and change context to it so runbook is able to query and find all automation variables. 

### Breaking Changes
N/A 

## Testing Evidence
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/146129702/b9be2855-4b6a-45c5-8919-e947563bd0f2)
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/146129702/bbbb58e5-9524-465f-92e9-a535cb1c8b8f)
![image](https://github.com/Azure/GuardrailsSolutionAccelerator/assets/146129702/0e4813fa-50a2-42c0-affd-7988e8a7340e)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/GuardrailsSolutionAccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/GuardrailsSolutionAccelerator/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/GuardrailsSolutionAccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Ensure PowerShell module versions have been updated (manually or with the ./tools/Update-ModuleVersions.ps1 script)
